### PR TITLE
Add extensible content parser with Markpub support

### DIFF
--- a/.github/changelog/content-parser
+++ b/.github/changelog/content-parser
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add rich content support for standard.site documents using the Markpub format.

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
 	},
 	"autoload": {
 		"classmap": [
-			"includes/",
-			"integrations/"
+			"includes/"
 		]
 	},
 	"scripts": {

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -13,7 +13,6 @@ use Atmosphere\OAuth\Client;
 use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Publication;
 use Atmosphere\Transformer\TID;
-use Atmosphere\Integrations\Load;
 use Atmosphere\WP_Admin\Admin;
 
 /**
@@ -43,9 +42,6 @@ class Atmosphere {
 
 		// JSON preview for AT Protocol records.
 		\add_action( 'template_redirect', array( $this, 'preview' ) );
-
-		// Plugin integrations.
-		Load::init();
 
 		// Post lifecycle hooks.
 		\add_action( 'transition_post_status', array( $this, 'on_status_change' ), 10, 3 );

--- a/includes/class-atmosphere.php
+++ b/includes/class-atmosphere.php
@@ -41,6 +41,9 @@ class Atmosphere {
 		\add_action( 'init', array( $this, 'register_wellknown_rewrite' ) );
 		\add_action( 'template_redirect', array( $this, 'serve_wellknown_publication' ) );
 
+		// JSON preview for AT Protocol records.
+		\add_action( 'template_redirect', array( $this, 'preview' ) );
+
 		// Plugin integrations.
 		Load::init();
 
@@ -142,6 +145,45 @@ class Atmosphere {
 		\status_header( 200 );
 		\header( 'Content-Type: text/plain; charset=utf-8' );
 		echo \esc_html( $uri );
+		exit;
+	}
+
+	/**
+	 * Serve a JSON preview of the AT Protocol record for a post.
+	 *
+	 * Append ?atproto to a singular post URL to see the document
+	 * record JSON. Optionally pass ?atproto={parser} to preview
+	 * with a specific content parser (requires the parser to be
+	 * registered via the atmosphere_content_parser filter).
+	 */
+	public function preview(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['atproto'] ) || ! \is_singular() ) {
+			return;
+		}
+
+		if ( ! \current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+
+		$post = \get_queried_object();
+
+		if ( ! $post instanceof \WP_Post ) {
+			return;
+		}
+
+		if ( ! \in_array( $post->post_type, Backfill::syncable_post_types(), true ) ) {
+			\status_header( 404 );
+			exit;
+		}
+
+		$transformer = new Document( $post );
+		$record      = $transformer->transform();
+
+		\status_header( 200 );
+		\header( 'Content-Type: application/json; charset=utf-8' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+		echo \wp_json_encode( $record, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 		exit;
 	}
 

--- a/includes/content-parser/class-markpub.php
+++ b/includes/content-parser/class-markpub.php
@@ -1,0 +1,374 @@
+<?php
+/**
+ * Markpub content parser.
+ *
+ * Converts WordPress block content into the at.markpub.markdown format
+ * by iterating Gutenberg blocks and converting each to its markdown
+ * equivalent.
+ *
+ * @see https://markpub.at/
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere\Content_Parser;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Markpub (at.markpub.markdown) content parser.
+ */
+class Markpub implements Content_Parser {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_type(): string {
+		return 'at.markpub.markdown';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @param string   $content Raw post content.
+	 * @param \WP_Post $post    The WordPress post object.
+	 */
+	public function parse( string $content, \WP_Post $post ): array { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$blocks = \parse_blocks( $content );
+		$parts  = array();
+
+		foreach ( $blocks as $block ) {
+			$md = self::transform_block( $block );
+
+			if ( null !== $md ) {
+				$parts[] = $md;
+			}
+		}
+
+		$markdown = \implode( "\n\n", $parts );
+
+		/**
+		 * Filters the markdown produced from post content.
+		 *
+		 * @param string $markdown Converted markdown.
+		 * @param string $content  Raw post content.
+		 */
+		$markdown = \apply_filters( 'atmosphere_html_to_markdown', $markdown, $content );
+
+		return array(
+			'$type'  => 'at.markpub.markdown',
+			'text'   => array(
+				'$type'    => 'at.markpub.text',
+				'markdown' => $markdown,
+			),
+			'flavor' => 'commonmark',
+		);
+	}
+
+	/**
+	 * Convert a single WordPress block to markdown.
+	 *
+	 * @param array $block Parsed block from parse_blocks().
+	 * @return string|null Markdown string or null to skip.
+	 */
+	private static function transform_block( array $block ): ?string {
+		if ( empty( $block['blockName'] ) ) {
+			// Classic (non-block) content or whitespace.
+			$html = \trim( $block['innerHTML'] ?? '' );
+			if ( empty( $html ) ) {
+				return null;
+			}
+
+			return self::inline_html_to_markdown( $html );
+		}
+
+		return match ( $block['blockName'] ) {
+			'core/paragraph'    => self::paragraph( $block ),
+			'core/heading'      => self::heading( $block ),
+			'core/image'        => self::image( $block ),
+			'core/list'         => self::listing( $block ),
+			'core/quote'        => self::quote( $block ),
+			'core/code'         => self::code( $block ),
+			'core/preformatted' => self::preformatted( $block ),
+			'core/separator'    => '---',
+			'core/spacer'       => null,
+			'core/group',
+			'core/columns',
+			'core/column'       => self::container( $block ),
+			default             => self::fallback( $block ),
+		};
+	}
+
+	/**
+	 * Paragraph block.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string|null
+	 */
+	private static function paragraph( array $block ): ?string {
+		$html = \trim( $block['innerHTML'] ?? '' );
+		if ( empty( $html ) ) {
+			return null;
+		}
+
+		return self::inline_html_to_markdown( $html );
+	}
+
+	/**
+	 * Heading block.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string|null
+	 */
+	private static function heading( array $block ): ?string {
+		$level = $block['attrs']['level'] ?? 2;
+		$text  = self::inline_html_to_markdown( $block['innerHTML'] ?? '' );
+
+		if ( empty( \trim( $text ) ) ) {
+			return null;
+		}
+
+		return \str_repeat( '#', (int) $level ) . ' ' . \trim( $text );
+	}
+
+	/**
+	 * Image block.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string|null
+	 */
+	private static function image( array $block ): ?string {
+		$html = $block['innerHTML'] ?? '';
+		$src  = '';
+		$alt  = '';
+
+		$processor = new \WP_HTML_Tag_Processor( $html );
+		if ( $processor->next_tag( 'IMG' ) ) {
+			$src = $processor->get_attribute( 'src' ) ?? '';
+			$alt = $processor->get_attribute( 'alt' ) ?? '';
+		}
+
+		if ( empty( $src ) ) {
+			return null;
+		}
+
+		$md = '![' . $alt . '](' . $src . ')';
+
+		// Check for a caption in figcaption.
+		$caption_proc = new \WP_HTML_Tag_Processor( $html );
+		if ( $caption_proc->next_tag( 'FIGCAPTION' ) ) {
+			$caption = \wp_strip_all_tags(
+				\preg_replace( '#.*<figcaption[^>]*>#si', '', $html )
+			);
+			$caption = \trim( \preg_replace( '#</figcaption>.*#si', '', $caption ) );
+
+			if ( ! empty( $caption ) ) {
+				$md .= "\n" . $caption;
+			}
+		}
+
+		return $md;
+	}
+
+	/**
+	 * List block.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string|null
+	 */
+	private static function listing( array $block ): ?string {
+		$ordered = ! empty( $block['attrs']['ordered'] );
+		$items   = array();
+
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			foreach ( $block['innerBlocks'] as $i => $inner ) {
+				$text = self::inline_html_to_markdown( $inner['innerHTML'] ?? '' );
+				$text = \trim( $text );
+
+				if ( empty( $text ) ) {
+					continue;
+				}
+
+				$prefix  = $ordered ? ( $i + 1 ) . '. ' : '- ';
+				$items[] = $prefix . $text;
+			}
+		}
+
+		return empty( $items ) ? null : \implode( "\n", $items );
+	}
+
+	/**
+	 * Quote block.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string|null
+	 */
+	private static function quote( array $block ): ?string {
+		$lines = array();
+
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			foreach ( $block['innerBlocks'] as $inner ) {
+				$md = self::transform_block( $inner );
+				if ( null !== $md ) {
+					$lines[] = $md;
+				}
+			}
+		}
+
+		if ( empty( $lines ) ) {
+			$text = self::inline_html_to_markdown( $block['innerHTML'] ?? '' );
+			if ( empty( \trim( $text ) ) ) {
+				return null;
+			}
+			$lines = array( \trim( $text ) );
+		}
+
+		$quoted = \implode( "\n", $lines );
+
+		// Prefix each line with >.
+		return \implode(
+			"\n",
+			\array_map(
+				static fn( $line ) => '> ' . $line,
+				\explode( "\n", $quoted )
+			)
+		);
+	}
+
+	/**
+	 * Code block.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string|null
+	 */
+	private static function code( array $block ): ?string {
+		$text = \wp_strip_all_tags( $block['innerHTML'] ?? '' );
+		$text = \html_entity_decode( $text, ENT_QUOTES, 'UTF-8' );
+		$text = \trim( $text );
+
+		if ( empty( $text ) ) {
+			return null;
+		}
+
+		$lang = $block['attrs']['language'] ?? '';
+
+		return '```' . $lang . "\n" . $text . "\n```";
+	}
+
+	/**
+	 * Preformatted block.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string|null
+	 */
+	private static function preformatted( array $block ): ?string {
+		return self::code( $block );
+	}
+
+	/**
+	 * Container block — flatten inner blocks.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string|null
+	 */
+	private static function container( array $block ): ?string {
+		if ( empty( $block['innerBlocks'] ) ) {
+			return null;
+		}
+
+		$parts = array();
+
+		foreach ( $block['innerBlocks'] as $inner ) {
+			$md = self::transform_block( $inner );
+			if ( null !== $md ) {
+				$parts[] = $md;
+			}
+		}
+
+		return empty( $parts ) ? null : \implode( "\n\n", $parts );
+	}
+
+	/**
+	 * Fallback for unknown block types.
+	 *
+	 * @param array $block Parsed block.
+	 * @return string|null
+	 */
+	private static function fallback( array $block ): ?string {
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			return self::container( $block );
+		}
+
+		$html = \trim( $block['innerHTML'] ?? '' );
+		if ( empty( $html ) ) {
+			return null;
+		}
+
+		return self::inline_html_to_markdown( $html );
+	}
+
+	/**
+	 * Convert inline HTML formatting to markdown.
+	 *
+	 * Handles links, bold, italic, strikethrough, inline code,
+	 * images, and line breaks. Strips block-level wrappers and
+	 * remaining tags.
+	 *
+	 * @param string $html HTML string.
+	 * @return string Markdown string.
+	 */
+	private static function inline_html_to_markdown( string $html ): string {
+		$html = \trim( $html );
+
+		if ( empty( $html ) ) {
+			return '';
+		}
+
+		$md = $html;
+
+		// Inline images.
+		$md = \preg_replace_callback(
+			'#<img[^>]+>#si',
+			static function ( $m ) {
+				$processor = new \WP_HTML_Tag_Processor( $m[0] );
+				if ( $processor->next_tag( 'IMG' ) ) {
+					$src = $processor->get_attribute( 'src' ) ?? '';
+					$alt = $processor->get_attribute( 'alt' ) ?? '';
+					return '![' . $alt . '](' . $src . ')';
+				}
+				return '';
+			},
+			$md
+		);
+
+		// Links.
+		$md = \preg_replace_callback(
+			'#<a[^>]+href=["\']([^"\']*)["\'][^>]*>(.*?)</a>#si',
+			static fn( $m ) => '[' . \wp_strip_all_tags( $m[2] ) . '](' . $m[1] . ')',
+			$md
+		);
+
+		// Bold.
+		$md = \preg_replace( '#<(?:strong|b)>(.*?)</(?:strong|b)>#si', '**$1**', $md );
+
+		// Italic.
+		$md = \preg_replace( '#<(?:em|i)>(.*?)</(?:em|i)>#si', '*$1*', $md );
+
+		// Strikethrough.
+		$md = \preg_replace( '#<(?:s|del|strike)>(.*?)</(?:s|del|strike)>#si', '~~$1~~', $md );
+
+		// Inline code.
+		$md = \preg_replace( '#<code>(.*?)</code>#si', '`$1`', $md );
+
+		// Line breaks.
+		$md = \preg_replace( '#<br\s*/?\s*>#si', "  \n", $md );
+
+		// Strip block-level wrappers and remaining tags.
+		$md = \wp_strip_all_tags( $md );
+
+		// Decode HTML entities.
+		$md = \html_entity_decode( $md, ENT_QUOTES, 'UTF-8' );
+
+		return \trim( $md );
+	}
+}

--- a/includes/content-parser/class-markpub.php
+++ b/includes/content-parser/class-markpub.php
@@ -56,12 +56,13 @@ class Markpub implements Content_Parser {
 		$markdown = \apply_filters( 'atmosphere_html_to_markdown', $markdown, $content );
 
 		return array(
-			'$type'  => 'at.markpub.markdown',
-			'text'   => array(
+			'$type'      => 'at.markpub.markdown',
+			'text'       => array(
 				'$type'    => 'at.markpub.text',
 				'markdown' => $markdown,
 			),
-			'flavor' => 'commonmark',
+			'flavor'     => 'gfm',
+			'extensions' => array( 'strikethrough', 'table' ),
 		);
 	}
 

--- a/includes/content-parser/interface-content-parser.php
+++ b/includes/content-parser/interface-content-parser.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Content parser interface for AT Protocol content formats.
+ *
+ * Plugins can implement this interface to provide custom content
+ * parsers for the site.standard.document content union field.
+ *
+ * @package Atmosphere
+ */
+
+namespace Atmosphere\Content_Parser;
+
+\defined( 'ABSPATH' ) || exit;
+
+/**
+ * Content parser contract.
+ */
+interface Content_Parser {
+
+	/**
+	 * Parse WordPress post content into an AT Protocol content object.
+	 *
+	 * The returned array must include a '$type' key identifying the
+	 * lexicon type (e.g. 'at.markpub.markdown').
+	 *
+	 * Receives raw post content so parsers can choose their own
+	 * strategy: parse_blocks() for block-aware parsing, or
+	 * apply_filters( 'the_content', ... ) for rendered HTML.
+	 *
+	 * @param string   $content Raw post content (post_content).
+	 * @param \WP_Post $post    The WordPress post object.
+	 * @return array AT Protocol content object.
+	 */
+	public function parse( string $content, \WP_Post $post ): array;
+
+	/**
+	 * The lexicon NSID this parser produces.
+	 *
+	 * @return string e.g. 'at.markpub.markdown'.
+	 */
+	public function get_type(): string;
+}

--- a/includes/transformer/class-document.php
+++ b/includes/transformer/class-document.php
@@ -57,10 +57,13 @@ class Document extends Base {
 			'publishedAt' => $this->to_iso8601( $this->object->post_date_gmt ),
 		);
 
-		// Publication reference.
+		// Publication reference (required by spec).
 		$pub_tid = \get_option( 'atmosphere_publication_tid' );
 		if ( $pub_tid ) {
 			$record['site'] = build_at_uri( get_did(), 'site.standard.publication', $pub_tid );
+		} else {
+			// Fall back to site URL for standalone documents.
+			$record['site'] = \untrailingslashit( \get_home_url() );
 		}
 
 		// Relative path.

--- a/includes/transformer/class-document.php
+++ b/includes/transformer/class-document.php
@@ -13,6 +13,8 @@ namespace Atmosphere\Transformer;
 
 \defined( 'ABSPATH' ) || exit;
 
+use Atmosphere\Content_Parser\Content_Parser;
+use Atmosphere\Content_Parser\Markpub;
 use function Atmosphere\build_at_uri;
 use function Atmosphere\get_did;
 use function Atmosphere\sanitize_text;
@@ -89,6 +91,12 @@ class Document extends Base {
 			$record['textContent'] = $text_content;
 		}
 
+		// Parsed rich content (open union).
+		$content = $this->get_content();
+		if ( ! empty( $content ) ) {
+			$record['content'] = $content;
+		}
+
 		// Tags.
 		$tags = $this->collect_tags( $this->object );
 		if ( ! empty( $tags ) ) {
@@ -138,6 +146,43 @@ class Document extends Base {
 		}
 
 		return $rkey;
+	}
+
+	/**
+	 * Get parsed content for the document's content union field.
+	 *
+	 * @return array|null Parsed content object or null.
+	 */
+	private function get_content(): ?array {
+		if ( empty( \trim( $this->object->post_content ) ) ) {
+			return null;
+		}
+
+		/**
+		 * Filters the content parser used for site.standard.document records.
+		 *
+		 * Return a Content_Parser instance to override the default parser.
+		 * Return null to disable the content field entirely.
+		 *
+		 * @param Content_Parser|null $parser The content parser. Default: Markpub.
+		 * @param \WP_Post            $post   The WordPress post.
+		 */
+		$parser = \apply_filters( 'atmosphere_content_parser', new Markpub(), $this->object );
+
+		if ( ! $parser instanceof Content_Parser ) {
+			return null;
+		}
+
+		$content = $parser->parse( $this->object->post_content, $this->object );
+
+		/**
+		 * Filters the parsed content object before adding to the document record.
+		 *
+		 * @param array          $content The parsed content object.
+		 * @param \WP_Post       $post    The WordPress post.
+		 * @param Content_Parser $parser  The parser that produced the content.
+		 */
+		return \apply_filters( 'atmosphere_document_content', $content, $this->object, $parser );
 	}
 
 	/**

--- a/tests/phpunit/tests/content-parser/class-test-markpub.php
+++ b/tests/phpunit/tests/content-parser/class-test-markpub.php
@@ -54,7 +54,8 @@ class Test_Markpub extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'text', $result );
 		$this->assertSame( 'at.markpub.text', $result['text']['$type'] );
 		$this->assertArrayHasKey( 'markdown', $result['text'] );
-		$this->assertSame( 'commonmark', $result['flavor'] );
+		$this->assertSame( 'gfm', $result['flavor'] );
+		$this->assertContains( 'strikethrough', $result['extensions'] );
 	}
 
 	/**

--- a/tests/phpunit/tests/content-parser/class-test-markpub.php
+++ b/tests/phpunit/tests/content-parser/class-test-markpub.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * Tests for the Markpub content parser.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group content-parser
+ */
+
+namespace Atmosphere\Tests\Content_Parser;
+
+use WP_UnitTestCase;
+use Atmosphere\Content_Parser\Markpub;
+
+/**
+ * Markpub parser tests.
+ */
+class Test_Markpub extends WP_UnitTestCase {
+
+	/**
+	 * Parser instance.
+	 *
+	 * @var Markpub
+	 */
+	private Markpub $parser;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->parser = new Markpub();
+	}
+
+	/**
+	 * Test get_type returns the markpub NSID.
+	 */
+	public function test_get_type() {
+		$this->assertSame( 'at.markpub.markdown', $this->parser->get_type() );
+	}
+
+	/**
+	 * Test parse returns correct top-level structure.
+	 */
+	public function test_parse_returns_correct_structure() {
+		$post   = self::factory()->post->create_and_get();
+		$result = $this->parser->parse(
+			'<!-- wp:paragraph --><p>Hello world</p><!-- /wp:paragraph -->',
+			$post
+		);
+
+		$this->assertArrayHasKey( '$type', $result );
+		$this->assertSame( 'at.markpub.markdown', $result['$type'] );
+		$this->assertArrayHasKey( 'text', $result );
+		$this->assertSame( 'at.markpub.text', $result['text']['$type'] );
+		$this->assertArrayHasKey( 'markdown', $result['text'] );
+		$this->assertSame( 'commonmark', $result['flavor'] );
+	}
+
+	/**
+	 * Test paragraph conversion.
+	 */
+	public function test_converts_paragraphs() {
+		$post    = self::factory()->post->create_and_get();
+		$content = "<!-- wp:paragraph -->\n<p>First paragraph</p>\n<!-- /wp:paragraph -->\n\n"
+			. "<!-- wp:paragraph -->\n<p>Second paragraph</p>\n<!-- /wp:paragraph -->";
+
+		$result   = $this->parser->parse( $content, $post );
+		$markdown = $result['text']['markdown'];
+
+		$this->assertStringContainsString( 'First paragraph', $markdown );
+		$this->assertStringContainsString( 'Second paragraph', $markdown );
+		$this->assertStringNotContainsString( '<p>', $markdown );
+	}
+
+	/**
+	 * Test heading conversion.
+	 */
+	public function test_converts_headings() {
+		$post    = self::factory()->post->create_and_get();
+		$content = '<!-- wp:heading {"level":2} --><h2>My Heading</h2><!-- /wp:heading -->';
+		$result  = $this->parser->parse( $content, $post );
+
+		$this->assertStringContainsString( '## My Heading', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test heading level 3.
+	 */
+	public function test_converts_heading_level_3() {
+		$post    = self::factory()->post->create_and_get();
+		$content = '<!-- wp:heading {"level":3} --><h3>Sub Heading</h3><!-- /wp:heading -->';
+		$result  = $this->parser->parse( $content, $post );
+
+		$this->assertStringContainsString( '### Sub Heading', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test link conversion in a paragraph.
+	 */
+	public function test_converts_links() {
+		$post    = self::factory()->post->create_and_get();
+		$content = '<!-- wp:paragraph --><p>Visit <a href="https://example.com">Example</a> today.</p><!-- /wp:paragraph -->';
+		$result  = $this->parser->parse( $content, $post );
+
+		$this->assertStringContainsString( '[Example](https://example.com)', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test bold conversion.
+	 */
+	public function test_converts_bold() {
+		$post    = self::factory()->post->create_and_get();
+		$content = '<!-- wp:paragraph --><p>This is <strong>bold</strong> text.</p><!-- /wp:paragraph -->';
+		$result  = $this->parser->parse( $content, $post );
+
+		$this->assertStringContainsString( '**bold**', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test italic conversion.
+	 */
+	public function test_converts_italic() {
+		$post    = self::factory()->post->create_and_get();
+		$content = '<!-- wp:paragraph --><p>This is <em>italic</em> text.</p><!-- /wp:paragraph -->';
+		$result  = $this->parser->parse( $content, $post );
+
+		$this->assertStringContainsString( '*italic*', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test image block conversion.
+	 */
+	public function test_converts_images() {
+		$post    = self::factory()->post->create_and_get();
+		$content = '<!-- wp:image --><figure class="wp-block-image"><img src="https://example.com/photo.jpg" alt="A photo" /></figure><!-- /wp:image -->';
+		$result  = $this->parser->parse( $content, $post );
+
+		$this->assertStringContainsString( '![A photo](https://example.com/photo.jpg)', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test code block conversion.
+	 */
+	public function test_converts_code_blocks() {
+		$post    = self::factory()->post->create_and_get();
+		$content = '<!-- wp:code --><pre class="wp-block-code"><code>echo "hello";</code></pre><!-- /wp:code -->';
+		$result  = $this->parser->parse( $content, $post );
+		$md      = $result['text']['markdown'];
+
+		$this->assertStringContainsString( '```', $md );
+		$this->assertStringContainsString( 'echo "hello";', $md );
+	}
+
+	/**
+	 * Test inline code conversion.
+	 */
+	public function test_converts_inline_code() {
+		$post    = self::factory()->post->create_and_get();
+		$content = '<!-- wp:paragraph --><p>Use the <code>parse()</code> method.</p><!-- /wp:paragraph -->';
+		$result  = $this->parser->parse( $content, $post );
+
+		$this->assertStringContainsString( '`parse()`', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test separator block becomes horizontal rule.
+	 */
+	public function test_converts_separator() {
+		$post    = self::factory()->post->create_and_get();
+		$content = "<!-- wp:paragraph --><p>Before</p><!-- /wp:paragraph -->\n\n"
+			. "<!-- wp:separator --><hr class=\"wp-block-separator\"/><!-- /wp:separator -->\n\n"
+			. '<!-- wp:paragraph --><p>After</p><!-- /wp:paragraph -->';
+		$result  = $this->parser->parse( $content, $post );
+
+		$this->assertStringContainsString( '---', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test empty content produces empty markdown.
+	 */
+	public function test_empty_content() {
+		$post   = self::factory()->post->create_and_get();
+		$result = $this->parser->parse( '', $post );
+
+		$this->assertSame( '', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test the atmosphere_html_to_markdown filter.
+	 */
+	public function test_html_to_markdown_filter() {
+		\add_filter(
+			'atmosphere_html_to_markdown',
+			static fn() => 'custom markdown',
+			10,
+			2
+		);
+
+		$post   = self::factory()->post->create_and_get();
+		$result = $this->parser->parse(
+			'<!-- wp:paragraph --><p>Hello</p><!-- /wp:paragraph -->',
+			$post
+		);
+
+		$this->assertSame( 'custom markdown', $result['text']['markdown'] );
+
+		\remove_all_filters( 'atmosphere_html_to_markdown' );
+	}
+
+	/**
+	 * Test strikethrough conversion.
+	 */
+	public function test_converts_strikethrough() {
+		$post    = self::factory()->post->create_and_get();
+		$content = '<!-- wp:paragraph --><p>This is <del>deleted</del> text.</p><!-- /wp:paragraph -->';
+		$result  = $this->parser->parse( $content, $post );
+
+		$this->assertStringContainsString( '~~deleted~~', $result['text']['markdown'] );
+	}
+
+	/**
+	 * Test classic (non-block) content is handled as fallback.
+	 */
+	public function test_classic_content_fallback() {
+		$post   = self::factory()->post->create_and_get();
+		$result = $this->parser->parse( '<p>Classic editor content with <strong>bold</strong>.</p>', $post );
+		$md     = $result['text']['markdown'];
+
+		$this->assertStringContainsString( '**bold**', $md );
+		$this->assertStringContainsString( 'Classic editor content', $md );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a pluggable content parser system for the `content` union field in `site.standard.document` records
- Ships a **Markpub** parser ([at.markpub.markdown](https://markpub.at/)) as the default, which walks Gutenberg blocks via `parse_blocks()` and converts each to CommonMark markdown
- Adds a `?atproto` preview endpoint on singular posts to inspect the document record JSON (requires `edit_posts` capability)

### Extensibility

Three filters provide full control:

| Filter | Purpose |
|---|---|
| `atmosphere_content_parser` | Swap the parser instance or return `null` to disable |
| `atmosphere_document_content` | Modify the parsed content object after parsing |
| `atmosphere_html_to_markdown` | Override the markdown conversion inside Markpub |

Custom parsers implement `Atmosphere\Content_Parser\Content_Parser` and return any AT Protocol content format.

### Block types handled

Paragraph, heading (with level), image (with alt/caption), list (ordered/unordered), quote, code, preformatted, separator, group/columns containers, plus fallback for unknown blocks and classic editor content.

## Test plan

- [ ] Verify `?atproto` preview on a published post returns valid JSON with `content` field
- [ ] Verify `?atproto` is not accessible when logged out
- [ ] Verify block content converts to markdown correctly (headings, links, images, lists, code blocks)
- [ ] Verify classic editor content falls back to inline HTML-to-markdown conversion
- [ ] Verify `atmosphere_content_parser` filter with `__return_null` disables the content field
- [ ] Run `npm run env-test` — all 39 tests pass