### PR TITLE
Add publication strongRef to link-card associatedRefs

### DIFF
--- a/.github/changelog/add-publication-strong-ref
+++ b/.github/changelog/add-publication-strong-ref
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Posts shared to Bluesky now link back to the site's publication record, so Bluesky can show your site's source alongside the link preview.

--- a/.github/changelog/add-publication-strong-ref
+++ b/.github/changelog/add-publication-strong-ref
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Posts shared to Bluesky now link back to the site's publication record, so Bluesky can show your site's source alongside the link preview.
+Posts shared to Bluesky now link back to both the site's publication record and the per-post document record, so Bluesky can show your site's source and richer document metadata alongside the link preview.

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -1346,7 +1346,7 @@ class Publisher {
 		 * reconnects, so the record always lands at the same address
 		 * for the active owner.
 		 */
-		return API::post(
+		$result = API::post(
 			'/xrpc/com.atproto.repo.putRecord',
 			array(
 				'repo'       => $did,
@@ -1355,6 +1355,23 @@ class Publisher {
 				'record'     => $pub->transform(),
 			)
 		);
+
+		/*
+		 * Capture the CID returned by the PDS so subsequent post
+		 * publishes can build an `app.bsky.embed.external#external`
+		 * `associatedRefs` strongRef without an extra `getRecord`
+		 * round-trip. The CID changes on every successful putRecord
+		 * (the publication's content hash changes whenever a site
+		 * option re-syncs the record), so it must be refreshed every
+		 * time, not just on the first write. A failure path here is
+		 * fine — the strongRef helper bails when the CID is missing
+		 * and the post still publishes with no `associatedRefs`.
+		 */
+		if ( ! \is_wp_error( $result ) && ! empty( $result['cid'] ) ) {
+			\update_option( Publication::OPTION_CID, (string) $result['cid'], false );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/includes/class-publisher.php
+++ b/includes/class-publisher.php
@@ -267,6 +267,26 @@ class Publisher {
 			)
 		);
 
+		/*
+		 * The initial post record shipped with the publication strongRef
+		 * only (a fresh-publish has no Document::META_URI / META_CID yet,
+		 * so `Post::build_embed()` could not yet attach the document
+		 * ref). Now that store_document_meta has landed the document's
+		 * URI + CID into post meta, re-transform the post and push the
+		 * augmented record via `applyWrites#update`. Bluesky's AppView
+		 * anchors its rich rendering (`source`, `associatedProfiles`,
+		 * the document's `createdAt` / `readingTime`) off the document
+		 * strongRef — without this follow-up the post visibly looks
+		 * identical to a no-associatedRefs publish.
+		 *
+		 * Failure here is non-fatal: the post + document already exist
+		 * on the PDS with the publication ref only, which is the same
+		 * state we would have shipped on a partial-failure rollback in
+		 * the AppView-pre-#standardsite era. Log and continue so the
+		 * subsequent `update_document_bsky_ref` still runs.
+		 */
+		self::update_post_associated_refs( $post, $bsky_transformer );
+
 		$doc_ref_result = self::update_document_bsky_ref( $post, $doc_transformer );
 		if ( \is_wp_error( $doc_ref_result ) ) {
 			return $doc_ref_result;
@@ -1611,6 +1631,133 @@ class Publisher {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Update the document record with the bsky root strong reference.
+	 *
+	 * After the initial applyWrites, the bsky root's CID is known, so
+	 * we re-transform the document (which picks up the ref via its
+	 * own read of `Post::META_URI` / `META_CID`) and persist via
+	 * `putRecord`. Called once per publish — the doc always references
+	 * the thread root, regardless of thread length.
+	 *
+	 * @param \WP_Post $post            WordPress post.
+	 * @param Document $doc_transformer Document transformer.
+	 * @return array|\WP_Error|null
+	 */
+	/**
+	 * Re-publish the post with its document strongRef appended to
+	 * `embed.external.associatedRefs`.
+	 *
+	 * Bluesky's AppView keys its rich treatment of standard.site
+	 * external embeds — the `source` / `associatedProfiles` / document
+	 * `readingTime` fields surfaced in `viewExternal` — off the
+	 * **document** strongRef inside `associatedRefs`. The publication
+	 * ref alone is syntactically valid but functionally invisible.
+	 * Filling the document ref needs its CID, which only exists after
+	 * the initial atomic applyWrites has returned and
+	 * `store_document_meta()` has copied the CID into post meta. This
+	 * helper closes that loop with a single `applyWrites#update` on the
+	 * post.
+	 *
+	 * The follow-up uses `applyWrites#update` rather than `putRecord`
+	 * because `bsky.social`'s PDS standardizes Publisher-side post
+	 * edits on `applyWrites#update` (see `update_post()`) — `putRecord`
+	 * works for our own custom collections (the document does it for
+	 * `bskyPostRef`) but is not the proven path for `app.bsky.feed.post`.
+	 *
+	 * Side-effects we have to handle:
+	 *
+	 *   - The post's CID changes. Update `Post::META_CID` and the
+	 *     mirror inside `META_THREAD_RECORDS[0]['cid']` so the
+	 *     subsequent `update_document_bsky_ref()` writes the document's
+	 *     `bskyPostRef` against the post's new CID, not the obsolete
+	 *     initial one.
+	 *
+	 *   - Failure is non-fatal. The post + document already exist on
+	 *     the PDS with the publication ref only, and the publish would
+	 *     have succeeded under that shape before this follow-up
+	 *     existed. Log the error breadcrumb so operators can spot
+	 *     repeated failures, then continue.
+	 *
+	 *   - Skip cleanly when the re-transformed embed has no
+	 *     `associatedRefs` at all (short-form posts, embed-filter
+	 *     suppressed). Nothing to update.
+	 *
+	 * @param \WP_Post $post             WordPress post.
+	 * @param Post     $bsky_transformer Bsky transformer instance (re-used so the
+	 *                                   freshly-populated meta is observed on the
+	 *                                   transform call).
+	 * @return array|\WP_Error|null `applyWrites` response on success, `WP_Error`
+	 *                              on a non-fatal failure, null when no update is
+	 *                              needed.
+	 */
+	private static function update_post_associated_refs(
+		\WP_Post $post,
+		Post $bsky_transformer
+	): array|\WP_Error|null {
+		$record = $bsky_transformer->transform();
+
+		// Short-form posts don't carry `app.bsky.embed.external`, so
+		// there is no `associatedRefs` to update. Same for the very
+		// rare case where the embed filter suppresses the embed
+		// entirely.
+		if ( ! isset( $record['embed']['external']['associatedRefs'] )
+			|| ! \is_array( $record['embed']['external']['associatedRefs'] )
+		) {
+			return null;
+		}
+
+		$writes = array(
+			array(
+				'$type'      => 'com.atproto.repo.applyWrites#update',
+				'collection' => 'app.bsky.feed.post',
+				'rkey'       => $bsky_transformer->get_rkey(),
+				'value'      => $record,
+			),
+		);
+
+		$result = API::apply_writes( $writes );
+
+		if ( \is_wp_error( $result ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			\error_log(
+				\sprintf(
+					'[atmosphere] post %d: associatedRefs follow-up failed (%s); record stays at publication-ref-only',
+					$post->ID,
+					$result->get_error_code()
+				)
+			);
+			return $result;
+		}
+
+		$new_cid = (string) ( $result['results'][0]['cid'] ?? '' );
+		if ( '' === $new_cid ) {
+			return $result;
+		}
+
+		/*
+		 * Mirror the new CID back into the post meta the rest of the
+		 * Publisher reads. Without these writes:
+		 *
+		 *   - `update_document_bsky_ref()` (called next) would stamp
+		 *     the document's `bskyPostRef.cid` to the obsolete initial
+		 *     CID, defeating the point of the strongRef.
+		 *   - Future reply/threading code that follows
+		 *     `META_THREAD_RECORDS[0]['cid']` for parent refs would
+		 *     point at a record version Bluesky no longer treats as
+		 *     authoritative.
+		 */
+		\update_post_meta( $post->ID, Post::META_CID, $new_cid );
+
+		$thread_records = \get_post_meta( $post->ID, Post::META_THREAD_RECORDS, true );
+		if ( \is_array( $thread_records ) && isset( $thread_records[0] ) && \is_array( $thread_records[0] ) ) {
+			$thread_records[0]['cid'] = $new_cid;
+			\update_post_meta( $post->ID, Post::META_THREAD_RECORDS, $thread_records );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -354,23 +354,53 @@ class Post extends Base {
 		}
 
 		/*
-		 * Attach the site's `site.standard.publication` strongRef so
-		 * AT Protocol consumers can navigate from the bsky post back
-		 * to the standard.site source. The Lexicon (`#external`) lists
-		 * `associatedRefs` as an array of strongRefs of the records
-		 * that backed the embed; Bluesky's manual-share UI already
-		 * emits this for URLs whose HTML carries our
-		 * `<link rel="site.standard.publication">` and document tags.
-		 * Building the embed by hand bypasses that lookup, so a
-		 * post published through Atmosphere otherwise ships with an
-		 * empty `associatedRefs`. The document strongRef cannot be
-		 * filled in here yet — its CID only exists after the
-		 * Publisher's atomic applyWrites — so this batch lands the
-		 * publication ref only; the document ref is a follow-up.
+		 * Attach strongRefs to the standard.site records that source
+		 * this view: the publication (always, once captured), and the
+		 * per-post document (only after the Publisher's initial
+		 * applyWrites populates `Document::META_URI` / `META_CID` and a
+		 * follow-up `applyWrites#update` re-fires this transformer).
+		 *
+		 * Bluesky's AppView keys its rich rendering — `source`,
+		 * `associatedProfiles`, the document's `createdAt` /
+		 * `readingTime` — off the document strongRef, so a record with
+		 * only the publication ref ships syntactically valid but
+		 * functionally invisible. The publication ref is still emitted
+		 * unconditionally because future AppView versions (and any
+		 * non-Bluesky consumer) can resolve through it on its own.
+		 *
+		 * Order: publication first, document second. The Lexicon does
+		 * not specify ordering, but pinning a deterministic order keeps
+		 * the test fixtures stable and matches the most-stable-first
+		 * pattern Bluesky's own manual-share UI uses.
 		 */
+		$associated_refs = array();
+
 		$publication_ref = Publication::get_strong_ref();
 		if ( null !== $publication_ref ) {
-			$external['associatedRefs'] = array( $publication_ref );
+			$associated_refs[] = $publication_ref;
+		}
+
+		/*
+		 * Document URI / CID live on `Document::META_*`, populated by
+		 * `Publisher::store_document_meta()` immediately after the
+		 * initial atomic applyWrites. Read them straight from meta
+		 * rather than spinning up another Document transformer — this
+		 * matches how `Document::transform()` itself reaches across
+		 * the type boundary for `Post::META_URI` / `META_CID` to fill
+		 * its bskyPostRef.
+		 */
+		$doc_uri = (string) \get_post_meta( $this->object->ID, Document::META_URI, true );
+		$doc_cid = (string) \get_post_meta( $this->object->ID, Document::META_CID, true );
+		if ( '' !== $doc_uri && '' !== $doc_cid ) {
+			$associated_refs[] = array(
+				'$type' => 'com.atproto.repo.strongRef',
+				'uri'   => $doc_uri,
+				'cid'   => $doc_cid,
+			);
+		}
+
+		if ( ! empty( $associated_refs ) ) {
+			$external['associatedRefs'] = $associated_refs;
 		}
 
 		return array(

--- a/includes/transformer/class-post.php
+++ b/includes/transformer/class-post.php
@@ -353,6 +353,26 @@ class Post extends Base {
 			}
 		}
 
+		/*
+		 * Attach the site's `site.standard.publication` strongRef so
+		 * AT Protocol consumers can navigate from the bsky post back
+		 * to the standard.site source. The Lexicon (`#external`) lists
+		 * `associatedRefs` as an array of strongRefs of the records
+		 * that backed the embed; Bluesky's manual-share UI already
+		 * emits this for URLs whose HTML carries our
+		 * `<link rel="site.standard.publication">` and document tags.
+		 * Building the embed by hand bypasses that lookup, so a
+		 * post published through Atmosphere otherwise ships with an
+		 * empty `associatedRefs`. The document strongRef cannot be
+		 * filled in here yet — its CID only exists after the
+		 * Publisher's atomic applyWrites — so this batch lands the
+		 * publication ref only; the document ref is a follow-up.
+		 */
+		$publication_ref = Publication::get_strong_ref();
+		if ( null !== $publication_ref ) {
+			$external['associatedRefs'] = array( $publication_ref );
+		}
+
 		return array(
 			'$type'    => 'app.bsky.embed.external',
 			'external' => $external,

--- a/includes/transformer/class-publication.php
+++ b/includes/transformer/class-publication.php
@@ -12,6 +12,8 @@ namespace Atmosphere\Transformer;
 
 \defined( 'ABSPATH' ) || exit;
 
+use function Atmosphere\build_at_uri;
+use function Atmosphere\get_did;
 use function Atmosphere\sanitize_text;
 
 /**
@@ -25,6 +27,31 @@ class Publication extends Base {
 	 * @var string
 	 */
 	public const OPTION_TID = 'atmosphere_publication_tid';
+
+	/**
+	 * Option key for the publication CID captured at the last successful
+	 * `sync_publication()` write.
+	 *
+	 * Stored so callers building strongRefs (currently the link-card
+	 * `embed.external.associatedRefs` array on outbound posts) don't need
+	 * to round-trip `getRecord` for a value the PDS already returned to
+	 * us when the publication was last written. The CID is allowed to be
+	 * stale relative to the live record — `getRecord` resolves by URI,
+	 * and the strongRef's CID just freezes the version we observed at
+	 * publish time, exactly the same snapshot semantics Bluesky's own
+	 * share UI uses when it builds `associatedRefs` from a URL's
+	 * standard.site links.
+	 *
+	 * `OPTION_TID` is the stable AT-URI identifier and survives
+	 * reconnect-to-the-same-account; the CID rotates every time the
+	 * publication record's content changes (theme color, site title,
+	 * etc.) and is re-captured on the next sync. Both options are
+	 * cleared on uninstall; neither is cleared on disconnect for the
+	 * same reason TID is preserved across disconnect today.
+	 *
+	 * @var string
+	 */
+	public const OPTION_CID = 'atmosphere_publication_cid';
 
 	/**
 	 * Transform site settings into a publication record.
@@ -101,6 +128,48 @@ class Publication extends Base {
 		}
 
 		return $rkey;
+	}
+
+	/**
+	 * Build a {@link https://atproto.com/specs/lexicon com.atproto.repo.strongRef}
+	 * pointing at the connected site's publication record, or null when
+	 * the strongRef cannot be safely constructed.
+	 *
+	 * Both the TID and the CID are required: the URI half is derivable
+	 * from the connected DID + the stored TID, but the strongRef shape
+	 * also needs the content-hash from {@see self::OPTION_CID}, which is
+	 * only populated after {@see \Atmosphere\Publisher::sync_publication()}
+	 * has successfully written the publication and read back the CID
+	 * from the PDS response. A fresh-connect install that has not yet
+	 * triggered a sync (typically through one of the `update_option_*`
+	 * triggers wired up in `Atmosphere::init()`) returns null here and
+	 * the caller — currently the link-card embed builder in
+	 * {@see \Atmosphere\Transformer\Post::build_embed()} — emits the
+	 * `embed.external` block without `associatedRefs`. The next sync
+	 * captures the CID and subsequent publishes pick the ref up
+	 * automatically.
+	 *
+	 * @return array{$type: string, uri: string, cid: string}|null
+	 */
+	public static function get_strong_ref(): ?array {
+		$tid = (string) \get_option( self::OPTION_TID, '' );
+		$cid = (string) \get_option( self::OPTION_CID, '' );
+
+		if ( '' === $tid || '' === $cid ) {
+			return null;
+		}
+
+		$did = get_did();
+
+		if ( '' === $did ) {
+			return null;
+		}
+
+		return array(
+			'$type' => 'com.atproto.repo.strongRef',
+			'uri'   => build_at_uri( $did, 'site.standard.publication', $tid ),
+			'cid'   => $cid,
+		);
 	}
 
 	/**

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -2370,4 +2370,97 @@ class Test_Publisher extends WP_UnitTestCase {
 		$this->assertWPError( $result );
 		$this->assertSame( 'atmosphere_not_connected', $result->get_error_code() );
 	}
+
+	/**
+	 * A successful `sync_publication()` captures the publication's CID
+	 * from the PDS response into the dedicated option. Without this
+	 * write, every post publish would have to round-trip `getRecord`
+	 * before it could build the `embed.external.associatedRefs`
+	 * strongRef to the publication. The CID rotates on every successful
+	 * putRecord (the publication's content hash changes whenever a
+	 * site option re-syncs the record), so the option must be
+	 * overwritten on each call rather than only set once.
+	 */
+	public function test_sync_publication_captures_cid_into_option() {
+		\update_option(
+			'atmosphere_identity',
+			array(
+				'did'          => 'did:plc:test123',
+				'handle'       => 'example.com',
+				'pds_endpoint' => 'https://pds.example.com',
+			),
+			false
+		);
+		\delete_option( \Atmosphere\Transformer\Publication::OPTION_CID );
+
+		$captured_url = '';
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) use ( &$captured_url ) {
+				if ( false === \strpos( $url, '/xrpc/com.atproto.repo.putRecord' ) ) {
+					return $response;
+				}
+
+				$captured_url = $url;
+				return array(
+					'response' => array( 'code' => 200 ),
+					'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+					'body'     => (string) \wp_json_encode(
+						array(
+							'uri' => 'at://did:plc:test123/site.standard.publication/3kpub00000000',
+							'cid' => 'bafyreipubfirstwrite00000000000000000000000000000000000000000',
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		$result = Publisher::sync_publication();
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'putRecord', $captured_url );
+		$this->assertSame(
+			'bafyreipubfirstwrite00000000000000000000000000000000000000000',
+			\get_option( \Atmosphere\Transformer\Publication::OPTION_CID )
+		);
+
+		// A subsequent successful sync must overwrite the cached CID —
+		// every putRecord produces a new content hash for the publication.
+		\remove_all_filters( 'pre_http_request' );
+		\add_filter(
+			'pre_http_request',
+			static function ( $response, $args, $url ) {
+				if ( false === \strpos( $url, '/xrpc/com.atproto.repo.putRecord' ) ) {
+					return $response;
+				}
+
+				return array(
+					'response' => array( 'code' => 200 ),
+					'headers'  => new \WpOrg\Requests\Utility\CaseInsensitiveDictionary( array() ),
+					'body'     => (string) \wp_json_encode(
+						array(
+							'uri' => 'at://did:plc:test123/site.standard.publication/3kpub00000000',
+							'cid' => 'bafyreipubsecondwrite0000000000000000000000000000000000000000',
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		Publisher::sync_publication();
+
+		$this->assertSame(
+			'bafyreipubsecondwrite0000000000000000000000000000000000000000',
+			\get_option( \Atmosphere\Transformer\Publication::OPTION_CID ),
+			'Each successful sync must overwrite the cached publication CID.'
+		);
+
+		\remove_all_filters( 'pre_http_request' );
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( \Atmosphere\Transformer\Publication::OPTION_CID );
+	}
 }

--- a/tests/phpunit/tests/class-test-publisher.php
+++ b/tests/phpunit/tests/class-test-publisher.php
@@ -20,6 +20,7 @@ use Atmosphere\OAuth\Encryption;
 use Atmosphere\Transformer\Comment;
 use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Post;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Publisher tests.
@@ -2369,6 +2370,123 @@ class Test_Publisher extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'atmosphere_not_connected', $result->get_error_code() );
+	}
+
+	/**
+	 * After the initial atomic create, `publish_post()` fires a
+	 * follow-up `applyWrites#update` on the post to inject the document
+	 * strongRef into `embed.external.associatedRefs`. Without it the
+	 * post stays at the publication-ref-only state, which Bluesky's
+	 * AppView refuses to enrich (`source`, `associatedProfiles`, the
+	 * document's `readingTime` are all keyed off the document ref).
+	 *
+	 * Asserts the two-call shape:
+	 *   1. Initial create — post (with publication ref only) + document.
+	 *   2. Follow-up update — post only, now with both refs.
+	 *
+	 * Also asserts the follow-up's new CID is mirrored back into
+	 * `Post::META_CID` and `META_THREAD_RECORDS[0]['cid']` so the next
+	 * `update_document_bsky_ref()` stamps the document's `bskyPostRef`
+	 * with the post's actual current CID, not the obsolete initial one.
+	 */
+	public function test_publish_post_follow_up_attaches_document_associated_ref() {
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication000000000000000000000000000000000000000000', false );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => 'Long form aside',
+				'post_content' => 'Long-form blog body.',
+			)
+		);
+
+		$this->register_capture( $post->ID );
+
+		Publisher::publish_post( $post );
+
+		$this->assertCount(
+			2,
+			$this->captured_calls,
+			'publish_post must fire two applyWrites: initial create + follow-up update.'
+		);
+
+		// Call 1: atomic create of post + document. The post record's
+		// embed carries the publication ref only because document meta
+		// is not populated yet at the initial transform.
+		$initial = $this->captured_calls[0]['writes'];
+		$this->assertCount( 2, $initial );
+		$this->assertSame( 'com.atproto.repo.applyWrites#create', $initial[0]['$type'] );
+		$this->assertSame( 'app.bsky.feed.post', $initial[0]['collection'] );
+
+		$initial_refs = $initial[0]['value']['embed']['external']['associatedRefs'] ?? array();
+		$this->assertCount( 1, $initial_refs, 'Initial post must carry only the publication ref.' );
+		$this->assertStringContainsString( '/site.standard.publication/', $initial_refs[0]['uri'] );
+
+		// Call 2: follow-up update of the post with both refs.
+		$followup = $this->captured_calls[1]['writes'];
+		$this->assertCount( 1, $followup );
+		$this->assertSame( 'com.atproto.repo.applyWrites#update', $followup[0]['$type'] );
+		$this->assertSame( 'app.bsky.feed.post', $followup[0]['collection'] );
+
+		$updated_refs = $followup[0]['value']['embed']['external']['associatedRefs'] ?? array();
+		$this->assertCount( 2, $updated_refs, 'Follow-up must add the document ref alongside the publication ref.' );
+		$this->assertStringContainsString( '/site.standard.publication/', $updated_refs[0]['uri'] );
+		$this->assertStringContainsString( '/site.standard.document/', $updated_refs[1]['uri'] );
+
+		// The new CID from the follow-up's response must be mirrored
+		// back into Post::META_CID so update_document_bsky_ref's
+		// bskyPostRef points at the post's current shape.
+		$expected_new_cid = $this->captured_calls[1]['response']['results'][0]['cid'];
+		$this->assertSame(
+			$expected_new_cid,
+			\get_post_meta( $post->ID, Post::META_CID, true ),
+			'Post::META_CID must update to the follow-up response CID.'
+		);
+
+		$thread_records = \get_post_meta( $post->ID, Post::META_THREAD_RECORDS, true );
+		$this->assertIsArray( $thread_records );
+		$this->assertSame(
+			$expected_new_cid,
+			$thread_records[0]['cid'],
+			'META_THREAD_RECORDS root CID must mirror the follow-up update.'
+		);
+
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
+	}
+
+	/**
+	 * Short-form posts use `app.bsky.embed.images` (or no embed at all),
+	 * neither of which carries `associatedRefs`. The Publisher's
+	 * follow-up `applyWrites#update` must skip cleanly rather than
+	 * shipping an empty / spurious update — the captured call count
+	 * stays at exactly one (the initial atomic create).
+	 */
+	public function test_publish_post_does_not_follow_up_for_short_form() {
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication000000000000000000000000000000000000000000', false );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status'  => 'publish',
+				'post_title'   => '',
+				'post_content' => 'A quick untitled thought.',
+			)
+		);
+
+		$this->register_capture( $post->ID );
+
+		Publisher::publish_post( $post );
+
+		$this->assertCount(
+			1,
+			$this->captured_calls,
+			'Short-form publish: only the initial create, no follow-up associatedRefs update.'
+		);
+
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -10,6 +10,7 @@
 namespace Atmosphere\Tests\Transformer;
 
 use WP_UnitTestCase;
+use Atmosphere\Transformer\Document;
 use Atmosphere\Transformer\Post;
 use Atmosphere\Transformer\Publication;
 
@@ -2108,6 +2109,61 @@ class Test_Post extends WP_UnitTestCase {
 
 		\delete_option( 'atmosphere_identity' );
 		\delete_option( Publication::OPTION_TID );
+	}
+
+	/**
+	 * Short-form posts use `app.bsky.embed.images` (or no embed at all),
+	 * not `app.bsky.embed.external` — `associatedRefs` is a field on the
+	 * external embed type, so it must not leak onto the short-form
+	 * path even when the publication state is fully populated.
+	 *
+	 * @covers ::transform
+	 */
+	/**
+	 * Once the Publisher's initial atomic applyWrites has landed the
+	 * document's URI + CID into `Document::META_*`, a re-transform of
+	 * the post picks up the document strongRef and appends it to
+	 * `associatedRefs` alongside the publication ref. This is what the
+	 * `Publisher::update_post_associated_refs()` follow-up reads back
+	 * before pushing the augmented record via `applyWrites#update`.
+	 *
+	 * Bluesky's AppView anchors its rich rendering (`source`,
+	 * `associatedProfiles`, document `readingTime`) off the document
+	 * ref specifically — the publication-ref-only state is
+	 * syntactically valid but functionally invisible.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_long_form_embed_includes_publication_and_document_refs_after_initial_publish() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication000000000000000000000000000000000000000000', false );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Long-form blog body.',
+			)
+		);
+
+		\update_post_meta( $post->ID, Document::META_URI, 'at://did:plc:test123/site.standard.document/3kdoc00000000' );
+		\update_post_meta( $post->ID, Document::META_CID, 'bafyreidoc000000000000000000000000000000000000000000000000000' );
+
+		$record = ( new Post( $post ) )->transform();
+
+		$refs = $record['embed']['external']['associatedRefs'];
+		$this->assertCount( 2, $refs );
+		$this->assertSame( 'at://did:plc:test123/site.standard.publication/3kpub00000000', $refs[0]['uri'] );
+		$this->assertSame( 'at://did:plc:test123/site.standard.document/3kdoc00000000', $refs[1]['uri'] );
+		$this->assertSame(
+			'bafyreidoc000000000000000000000000000000000000000000000000000',
+			$refs[1]['cid']
+		);
+		$this->assertSame( 'com.atproto.repo.strongRef', $refs[1]['$type'] );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
 	}
 
 	/**

--- a/tests/phpunit/tests/transformer/class-test-post.php
+++ b/tests/phpunit/tests/transformer/class-test-post.php
@@ -11,6 +11,7 @@ namespace Atmosphere\Tests\Transformer;
 
 use WP_UnitTestCase;
 use Atmosphere\Transformer\Post;
+use Atmosphere\Transformer\Publication;
 
 /**
  * Post transformer tests.
@@ -2029,5 +2030,113 @@ class Test_Post extends WP_UnitTestCase {
 		);
 
 		$this->assertNull( Post::get_attachment_aspect_ratio( $attachment_id ) );
+	}
+
+	/*
+	 * -----------------------------------------------------------------
+	 * Link-card embed — associatedRefs for the publication strongRef.
+	 * -----------------------------------------------------------------
+	 */
+
+	/**
+	 * Long-form posts ship the site's publication strongRef in
+	 * `embed.external.associatedRefs` when the publication TID + CID
+	 * are both on file. Lifts the link-card embed close to parity with
+	 * what Bluesky's manual-share UI emits when it follows the
+	 * standard.site link tags from the same URL — without the ref,
+	 * downstream consumers can't navigate from the bsky post back to
+	 * the publication record.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_long_form_embed_includes_publication_associated_ref_when_state_present() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication000000000000000000000000000000000000000000', false );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Long-form blog body.',
+				'post_excerpt' => 'Teaser excerpt.',
+			)
+		);
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertSame( 'app.bsky.embed.external', $record['embed']['$type'] );
+		$this->assertArrayHasKey( 'associatedRefs', $record['embed']['external'] );
+		$this->assertCount( 1, $record['embed']['external']['associatedRefs'] );
+
+		$ref = $record['embed']['external']['associatedRefs'][0];
+		$this->assertSame( 'com.atproto.repo.strongRef', $ref['$type'] );
+		$this->assertSame( 'at://did:plc:test123/site.standard.publication/3kpub00000000', $ref['uri'] );
+		$this->assertSame( 'bafyreipublication000000000000000000000000000000000000000000', $ref['cid'] );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
+	}
+
+	/**
+	 * On a fresh install where `Publisher::sync_publication()` has not
+	 * yet captured a CID, the link-card embed must ship without
+	 * `associatedRefs` rather than with a malformed (CID-less)
+	 * strongRef. Locks the graceful-degradation contract: every other
+	 * field on `external` must still be emitted normally.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_long_form_embed_omits_associated_refs_when_publication_cid_is_missing() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\delete_option( Publication::OPTION_CID );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => 'A Titled Post',
+				'post_content' => 'Long-form blog body.',
+			)
+		);
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertSame( 'app.bsky.embed.external', $record['embed']['$type'] );
+		$this->assertArrayNotHasKey( 'associatedRefs', $record['embed']['external'] );
+		$this->assertArrayHasKey( 'uri', $record['embed']['external'] );
+		$this->assertArrayHasKey( 'title', $record['embed']['external'] );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+	}
+
+	/**
+	 * Short-form posts use `app.bsky.embed.images` (or no embed at all),
+	 * not `app.bsky.embed.external` — `associatedRefs` is a field on the
+	 * external embed type, so it must not leak onto the short-form
+	 * path even when the publication state is fully populated.
+	 *
+	 * @covers ::transform
+	 */
+	public function test_short_form_post_never_carries_publication_associated_ref() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication000000000000000000000000000000000000000000', false );
+
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_title'   => '',
+				'post_content' => 'A quick untitled thought.',
+			)
+		);
+
+		$record = ( new Post( $post ) )->transform();
+
+		$this->assertSame( 'A quick untitled thought.', $record['text'] );
+		$this->assertArrayNotHasKey( 'embed', $record );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
 	}
 }

--- a/tests/phpunit/tests/transformer/class-test-publication.php
+++ b/tests/phpunit/tests/transformer/class-test-publication.php
@@ -183,4 +183,63 @@ class Test_Publication extends WP_UnitTestCase {
 		$this->assertSame( "Toni's blog & Co", $record['name'] );
 		$this->assertSame( "Books, coffee & friends'", $record['description'] );
 	}
+
+	/**
+	 * `get_strong_ref()` returns a well-formed strongRef when both the
+	 * TID and CID options are populated and the site has an identity.
+	 * Locks the at-uri composition (`at://<did>/<collection>/<tid>`)
+	 * and the strongRef shape the Lexicon expects.
+	 */
+	public function test_get_strong_ref_returns_shape_when_all_state_is_present() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication000000000000000000000000000000000000000000', false );
+
+		$ref = Publication::get_strong_ref();
+
+		$this->assertIsArray( $ref );
+		$this->assertSame( 'com.atproto.repo.strongRef', $ref['$type'] );
+		$this->assertSame( 'at://did:plc:test123/site.standard.publication/3kpub00000000', $ref['uri'] );
+		$this->assertSame( 'bafyreipublication000000000000000000000000000000000000000000', $ref['cid'] );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
+	}
+
+	/**
+	 * `get_strong_ref()` returns null when the CID has not yet been
+	 * captured by a successful `sync_publication()`. Reaching the AT-URI
+	 * is fine on its own (TID is generated lazily by `get_rkey()`), but
+	 * a strongRef without a CID is malformed — graceful degradation is
+	 * the right behaviour so the caller skips the `associatedRefs`
+	 * entry until the publication has actually been written.
+	 */
+	public function test_get_strong_ref_returns_null_when_cid_is_missing() {
+		\update_option( 'atmosphere_identity', array( 'did' => 'did:plc:test123' ), false );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\delete_option( Publication::OPTION_CID );
+
+		$this->assertNull( Publication::get_strong_ref() );
+
+		\delete_option( 'atmosphere_identity' );
+		\delete_option( Publication::OPTION_TID );
+	}
+
+	/**
+	 * `get_strong_ref()` returns null on a disconnected install — no
+	 * identity means no DID to base the at-uri on, even if the TID +
+	 * CID survived a previous connection. Prevents a stale strongRef
+	 * pointing at a DID the current install does not own.
+	 */
+	public function test_get_strong_ref_returns_null_without_identity() {
+		\delete_option( 'atmosphere_identity' );
+		\update_option( Publication::OPTION_TID, '3kpub00000000', false );
+		\update_option( Publication::OPTION_CID, 'bafyreipublication000000000000000000000000000000000000000000', false );
+
+		$this->assertNull( Publication::get_strong_ref() );
+
+		\delete_option( Publication::OPTION_TID );
+		\delete_option( Publication::OPTION_CID );
+	}
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -26,6 +26,7 @@ $atmosphere_options = array(
 	'atmosphere_connection',
 	'atmosphere_identity',
 	'atmosphere_publication_tid',
+	'atmosphere_publication_cid',
 	'atmosphere_publication_uri',
 	'atmosphere_auto_publish',
 	// Legacy: written by set_handle() in 1.0.x and 1.1.0 as a revert


### PR DESCRIPTION
## Proposed changes:

Posts ATmosphere publishes to Bluesky build their `app.bsky.embed.external` link card by hand rather than letting Bluesky's share UI fetch the URL. The Lexicon defines `external.associatedRefs` as an array of strongRefs of the records that backed the embed, and Bluesky's manual-share UI already populates it for any URL whose HTML carries our `<link rel=\"site.standard.publication\">` / `<link rel=\"site.standard.document\">` tags. A post we publish ourselves should advertise the same field — otherwise the bsky-side UI loses the navigable link back to the standard.site source.

Compare what Bluesky's share UI ships for the [same URL](https://bsky.app/profile/jeherve.com/post/3mn6layvcfs2e) vs. what [our publisher](https://bsky.app/profile/did:plc:4i6hvdii3km3kbnj3losmwnt/post/3mn6kp4mh4oum) ships — the manual share has `associatedRefs` with strongRefs for both the document and the publication; the Atmosphere post has neither.

This PR handles the **publication** half. The publication is written once at connect (and re-synced on theme + site-option changes), so its CID is observable from the existing `putRecord` response — we just need to capture it.

* `Publication::OPTION_CID` (new option `atmosphere_publication_cid`) stores the CID the PDS returns on each successful `Publisher::sync_publication()`. The CID rotates on every successful putRecord (the publication's content hash changes whenever the record's content does), so the option is overwritten every call — not just on first write.
* `Publication::get_strong_ref()` builds the `com.atproto.repo.strongRef` from the stored TID + CID + connected DID, or returns `null` if any of those are missing.
* `Post::build_embed()` appends the ref as the sole entry in `external.associatedRefs`. Missing state → field is simply omitted; the embed is still valid.
* `uninstall.php` sweeps the new option alongside the existing publication state.

### Out of scope

The **document** strongRef (the per-post companion) needs its CID before the atomic `applyWrites`, which is the chicken-and-egg case I called out separately. Two paths there — a follow-up `applyWrites#update`, or a client-side DAG-CBOR encoder so we can compute the document CID locally — both are bigger changes that warrant their own review. Splitting them out so this user-visible win can land now.

### Existing installs

`get_strong_ref()` returns `null` until the next `sync_publication` trigger captures the CID. The plugin already re-syncs on theme changes, site URL updates, etc., so most installs pick it up on the first post-merge admin save. Until then, posts publish without `associatedRefs` (same as today). No backfill needed.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

Three new test groups:

* `Test_Publication`: `get_strong_ref()` returns the right shape with full state, null when CID is missing, null without identity.
* `Test_Post`: long-form embed includes the ref when state is present, omits it when CID is missing, never leaks onto short-form posts (which use `app.bsky.embed.images` and don't have `associatedRefs` in their lexicon).
* `Test_Publisher`: `sync_publication()` captures the CID into the option and overwrites it on each call.

## Testing instructions:

1. Connect a site to ATmosphere.
2. Trigger a publication sync (Settings → General → save anything, or change the active theme — either fires the existing `schedule_publication_sync` hook).
3. \`wp option get atmosphere_publication_cid\` — confirm a `bafyrei…` value is now stored.
4. Publish a new titled blog post and inspect the resulting bsky record via `pdsls.dev` or `curl -s https://public.api.bsky.app/xrpc/com.atproto.repo.getRecord?repo=<did>&collection=app.bsky.feed.post&rkey=<rkey>`.
5. Confirm `value.embed.external.associatedRefs[0]` is a `com.atproto.repo.strongRef` whose `uri` matches `at://<did>/site.standard.publication/<your-publication-tid>` and whose `cid` matches the captured option.
6. Delete the cached CID (\`wp option delete atmosphere_publication_cid\`), publish another post, confirm the new record's `external` has no `associatedRefs` field — graceful degradation rather than a malformed strongRef.

Automated:
* `composer lint`
* `npm run env-test`

### Changelog entry

Already committed at `.github/changelog/add-publication-strong-ref` (Patch / Added).