### PR TITLE
Add PDS account management link

### DIFF
--- a/.github/changelog/add-pds-account-management-link
+++ b/.github/changelog/add-pds-account-management-link
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+The settings page now links to your AT Protocol account management page when your Personal Data Server provides one.

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -17,6 +17,7 @@ use Atmosphere\Content_Parser\Pckt;
 use Atmosphere\Content_Parser\Registry;
 use Atmosphere\Handle;
 use function Atmosphere\get_connection;
+use function Atmosphere\get_identity;
 use function Atmosphere\get_supported_post_types;
 use function Atmosphere\has_identity;
 use function Atmosphere\is_connected;
@@ -170,6 +171,11 @@ class Settings_Fields {
 	 */
 	public static function render_connected_section(): void {
 		$connection     = get_connection();
+		$identity       = get_identity();
+		$handle         = (string) ( $identity['handle'] ?? $connection['handle'] ?? '' );
+		$did            = (string) ( $identity['did'] ?? $connection['did'] ?? '' );
+		$pds_endpoint   = (string) ( $identity['pds_endpoint'] ?? $connection['pds_endpoint'] ?? '' );
+		$account_url    = self::pds_account_management_url( $pds_endpoint );
 		$disconnect_url = \wp_nonce_url(
 			\admin_url( 'admin-post.php?action=atmosphere_disconnect' ),
 			'atmosphere_disconnect',
@@ -181,27 +187,32 @@ class Settings_Fields {
 			<tr>
 				<th scope="row"><?php \esc_html_e( 'Handle', 'atmosphere' ); ?></th>
 				<td>
-					<strong><?php echo \esc_html( $connection['handle'] ?? '' ); ?></strong>
+					<strong><?php echo \esc_html( $handle ); ?></strong>
 					<p class="description"><?php \esc_html_e( 'Your public AT Protocol identity, similar to a username.', 'atmosphere' ); ?></p>
 				</td>
 			</tr>
 			<tr>
 				<th scope="row"><?php \esc_html_e( 'DID', 'atmosphere' ); ?></th>
 				<td>
-					<code><?php echo \esc_html( $connection['did'] ?? '' ); ?></code>
+					<code><?php echo \esc_html( $did ); ?></code>
 					<p class="description"><?php \esc_html_e( 'Your Decentralized Identifier — a permanent, portable ID that stays the same even if you change your handle.', 'atmosphere' ); ?></p>
 				</td>
 			</tr>
 			<tr>
 				<th scope="row"><?php \esc_html_e( 'PDS', 'atmosphere' ); ?></th>
 				<td>
-					<code><?php echo \esc_html( $connection['pds_endpoint'] ?? '' ); ?></code>
+					<code><?php echo \esc_html( $pds_endpoint ); ?></code>
 					<p class="description"><?php \esc_html_e( 'Your Personal Data Server — where your AT Protocol records are stored and served from.', 'atmosphere' ); ?></p>
 				</td>
 			</tr>
 			<tr>
 				<th scope="row"></th>
 				<td>
+					<?php if ( '' !== $account_url ) : ?>
+						<a href="<?php echo \esc_url( $account_url ); ?>" class="button" target="_blank" rel="noopener noreferrer">
+							<?php \esc_html_e( 'Manage AT Protocol account', 'atmosphere' ); ?>
+						</a>
+					<?php endif; ?>
 					<a href="<?php echo \esc_url( $disconnect_url ); ?>" class="button">
 						<?php \esc_html_e( 'Disconnect', 'atmosphere' ); ?>
 					</a>
@@ -209,6 +220,34 @@ class Settings_Fields {
 			</tr>
 		</table>
 		<?php
+	}
+
+	/**
+	 * Build the account-management URL for a PDS endpoint.
+	 *
+	 * The PDS endpoint is stored from DID resolution, but this render path
+	 * should still fail closed for legacy or hand-edited options. The account
+	 * UI currently lives at the reference PDS host's `/account` path, not at
+	 * an appview host or XRPC endpoint.
+	 *
+	 * @param string $pds_endpoint PDS service endpoint.
+	 * @return string Account-management URL, or empty string when unavailable.
+	 */
+	private static function pds_account_management_url( string $pds_endpoint ): string {
+		if ( '' === $pds_endpoint ) {
+			return '';
+		}
+
+		$parts = \wp_parse_url( $pds_endpoint );
+
+		if ( ! \is_array( $parts ) || 'https' !== ( $parts['scheme'] ?? '' ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$host = $parts['host'];
+		$port = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
+
+		return "https://{$host}{$port}/account";
 	}
 
 	/**

--- a/includes/wp-admin/class-settings-fields.php
+++ b/includes/wp-admin/class-settings-fields.php
@@ -240,11 +240,21 @@ class Settings_Fields {
 
 		$parts = \wp_parse_url( $pds_endpoint );
 
-		if ( ! \is_array( $parts ) || 'https' !== ( $parts['scheme'] ?? '' ) || empty( $parts['host'] ) ) {
+		if (
+			! \is_array( $parts )
+			|| 'https' !== ( $parts['scheme'] ?? '' )
+			|| empty( $parts['host'] )
+			|| isset( $parts['user'] )
+			|| isset( $parts['pass'] )
+		) {
 			return '';
 		}
 
 		$host = $parts['host'];
+		if ( \str_contains( $host, ':' ) && ! \str_starts_with( $host, '[' ) ) {
+			$host = '[' . $host . ']';
+		}
+
 		$port = isset( $parts['port'] ) ? ':' . (int) $parts['port'] : '';
 
 		return "https://{$host}{$port}/account";

--- a/tests/phpunit/tests/wp-admin/class-test-settings-fields.php
+++ b/tests/phpunit/tests/wp-admin/class-test-settings-fields.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Tests for settings page field rendering.
+ *
+ * @package Atmosphere
+ * @group atmosphere
+ * @group wp-admin
+ */
+
+namespace Atmosphere\Tests\WP_Admin;
+
+use Atmosphere\WP_Admin\Settings_Fields;
+
+/**
+ * Settings field rendering tests.
+ */
+class Test_Settings_Fields extends \WP_UnitTestCase {
+
+	/**
+	 * Clean up connection state after each test.
+	 */
+	public function tear_down(): void {
+		\delete_option( 'atmosphere_connection' );
+		\delete_option( 'atmosphere_identity' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Render the connected section and return the buffered HTML.
+	 *
+	 * @return string Rendered HTML.
+	 */
+	private function render_connected_section(): string {
+		\ob_start();
+		Settings_Fields::render_connected_section();
+		return (string) \ob_get_clean();
+	}
+
+	/**
+	 * Connected users can open their PDS account-management page.
+	 */
+	public function test_connected_section_renders_pds_account_management_link(): void {
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.example.com',
+				'did'          => 'did:plc:alice',
+				'pds_endpoint' => 'https://pds.example.com/',
+				'access_token' => 'token',
+			)
+		);
+
+		$html = $this->render_connected_section();
+
+		$this->assertStringContainsString( 'Manage AT Protocol account', $html );
+		$this->assertStringContainsString( 'href="https://pds.example.com/account"', $html );
+		$this->assertStringContainsString( 'target="_blank"', $html );
+		$this->assertStringContainsString( 'rel="noopener noreferrer"', $html );
+		$this->assertStringContainsString( 'Disconnect', $html );
+	}
+
+	/**
+	 * No account-management link is rendered when no PDS endpoint is stored.
+	 */
+	public function test_connected_section_hides_account_management_link_without_pds_endpoint(): void {
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.example.com',
+				'did'          => 'did:plc:alice',
+				'access_token' => 'token',
+			)
+		);
+
+		$html = $this->render_connected_section();
+
+		$this->assertStringNotContainsString( 'Manage AT Protocol account', $html );
+		$this->assertStringContainsString( 'Disconnect', $html );
+	}
+
+	/**
+	 * The identity option is the canonical source for account details.
+	 */
+	public function test_connected_section_uses_identity_pds_endpoint_for_account_management_link(): void {
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'access_token' => 'token',
+			)
+		);
+		\update_option(
+			'atmosphere_identity',
+			array(
+				'handle'       => 'alice.example.com',
+				'did'          => 'did:plc:alice',
+				'pds_endpoint' => 'https://pds.identity.example',
+			)
+		);
+
+		$html = $this->render_connected_section();
+
+		$this->assertStringContainsString( 'alice.example.com', $html );
+		$this->assertStringContainsString( 'did:plc:alice', $html );
+		$this->assertStringContainsString( 'https://pds.identity.example', $html );
+		$this->assertStringContainsString( 'href="https://pds.identity.example/account"', $html );
+	}
+
+	/**
+	 * Hand-edited unsafe PDS endpoints must not become admin links.
+	 */
+	public function test_connected_section_hides_account_management_link_for_unsafe_pds_endpoint(): void {
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.example.com',
+				'did'          => 'did:plc:alice',
+				'pds_endpoint' => 'http://pds.example.com',
+				'access_token' => 'token',
+			)
+		);
+
+		$html = $this->render_connected_section();
+
+		$this->assertStringNotContainsString( 'Manage AT Protocol account', $html );
+		$this->assertStringNotContainsString( 'href="http://pds.example.com/account"', $html );
+		$this->assertStringContainsString( 'Disconnect', $html );
+	}
+}

--- a/tests/phpunit/tests/wp-admin/class-test-settings-fields.php
+++ b/tests/phpunit/tests/wp-admin/class-test-settings-fields.php
@@ -126,4 +126,46 @@ class Test_Settings_Fields extends \WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'href="http://pds.example.com/account"', $html );
 		$this->assertStringContainsString( 'Disconnect', $html );
 	}
+
+	/**
+	 * PDS endpoints with userinfo must not become admin links.
+	 */
+	public function test_connected_section_hides_account_management_link_for_pds_endpoint_with_userinfo(): void {
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.example.com',
+				'did'          => 'did:plc:alice',
+				'pds_endpoint' => 'https://pds.example.com@evil.example',
+				'access_token' => 'token',
+			)
+		);
+
+		$html = $this->render_connected_section();
+
+		$this->assertStringNotContainsString( 'Manage AT Protocol account', $html );
+		$this->assertStringNotContainsString( 'href="https://evil.example/account"', $html );
+		$this->assertStringContainsString( 'Disconnect', $html );
+	}
+
+	/**
+	 * Valid IPv6 literal PDS hosts can still render account-management links.
+	 */
+	public function test_connected_section_renders_account_management_link_for_ipv6_pds_endpoint(): void {
+		\update_option(
+			'atmosphere_connection',
+			array(
+				'handle'       => 'alice.example.com',
+				'did'          => 'did:plc:alice',
+				'pds_endpoint' => 'https://[2001:db8::1]:8443',
+				'access_token' => 'token',
+			)
+		);
+
+		$html = $this->render_connected_section();
+
+		$this->assertStringContainsString( 'Manage AT Protocol account', $html );
+		$this->assertStringContainsString( 'href="https://[2001:db8::1]:8443/account"', $html );
+		$this->assertStringContainsString( 'Disconnect', $html );
+	}
 }


### PR DESCRIPTION
Fixes #160

## Proposed changes:
* Add a Manage AT Protocol account button to the connected-account section of the ATmosphere settings page.
* Build the link from the connected account's PDS service endpoint using the current reference-PDS `/account` UI path, without using appview host settings.
* Hide the link when no HTTPS PDS endpoint is available.
* Add PHPUnit coverage for rendering, missing PDS endpoints, canonical identity fallback, and unsafe endpoint rejection.

### Other information:

- [x] Have you written new tests for your changes, if applicable?

## Testing instructions:
* Connect ATmosphere to an AT Protocol account whose stored PDS endpoint is known.
* Go to Settings → ATmosphere.
* Confirm the Connection section shows a Manage AT Protocol account button next to Disconnect.
* Confirm the button opens `https://{pds-host}/account` in a new tab.
* Confirm existing Disconnect behavior is unchanged.

Automated verification run locally:
* `composer lint`
* `npm run env-test`

### Changelog entry

A manual changelog entry is included in `.github/changelog/add-pds-account-management-link`.

-   [ ] Automatically create a changelog entry from the details below.

<details>

<summary>Changelog Entry Details</summary>

#### Significance

-   [ ] Patch
-   [ ] Minor
-   [ ] Major

#### Type

-   [ ] Added - for new features
-   [ ] Changed - for changes in existing functionality
-   [ ] Deprecated - for soon-to-be removed features
-   [ ] Removed - for now removed features
-   [ ] Fixed - for any bug fixes
-   [ ] Security - in case of vulnerabilities

#### Message

</details>